### PR TITLE
fix: type definition file on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "A spinning activity indicator for kintone",
   "main": "dist/kintone-spinner.min.js",
+  "types": "index.d.ts",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
- https://github.com/goqoo-on-kintone/kintone-spinner/pull/2 の追加修正になります。
- `package.json` で型定義ファイルを指定してやる必要がありました。 

確認不足ですみません💦
よろしくお願いいたします。